### PR TITLE
[BugFix] 저장하기 alert와 뒤로가기 alert 분리

### DIFF
--- a/Chinggu/Chinggu/WriteComplimentView.swift
+++ b/Chinggu/Chinggu/WriteComplimentView.swift
@@ -105,14 +105,15 @@ struct WriteComplimentView: View {
     @State private var presentSheet = false
     @FocusState private var isFocused: Bool
     @Environment(\.dismiss) private var dismiss
-    @State private var showingAlert = false
+    @State private var showingGoBackAlert = false
+    @State private var showingSaveAlert = false
     @State private var goBackAlert = SaveAlert(title: "정말로 나가시겠어요?", description: "작성된 내용은 저장되지 않습니다.")
     @State private var saveAlert = SaveAlert(title: "정말로 저장하시겠어요?", description: "칭찬은 하루에 한 번만 쓸 수 있고\n수정할 수 없어요.")
     
     @AppStorage("group") var groupOrder: Int = UserDefaults.standard.integer(forKey: "groupID")
     
-    func showAlert () {
-        showingAlert = true
+    func showSaveAlert () {
+        showingSaveAlert = true
     }
     
     func saveContent () {
@@ -232,7 +233,7 @@ struct WriteComplimentView: View {
                     guard !content.isEmpty else {
                         return dismiss()
                     }
-                    showingAlert = true
+                    showingGoBackAlert = true
                 })
                 {
                     HStack {
@@ -241,7 +242,7 @@ struct WriteComplimentView: View {
                     }
                     .foregroundColor(Color.black)
                 }
-                .alert(goBackAlert.title, isPresented: $showingAlert, presenting: goBackAlert) {saveAlert in
+                .alert(goBackAlert.title, isPresented: $showingGoBackAlert, presenting: goBackAlert) {saveAlert in
                     Button("네", action: dismiss.callAsFunction)
                     Button("취소", role: .cancel) {}
                 } message: {article in
@@ -249,9 +250,9 @@ struct WriteComplimentView: View {
                 }
             }
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button("저장", action: showAlert)
+                Button("저장", action: showSaveAlert)
                     .disabled(content.isEmpty ? true : false)
-                    .alert(saveAlert.title, isPresented: $showingAlert, presenting: saveAlert) {saveAlert in
+                    .alert(saveAlert.title, isPresented: $showingSaveAlert, presenting: saveAlert) {saveAlert in
                         Button("네", action: saveContent)
                         Button("취소", role: .cancel) {}
                     } message: {article in


### PR DESCRIPTION
### Description
 - 저장하기 alert와 뒤로가기 alert를 보여주는 변수를 같이 처리하고 있어 이를 분리하여 서로 중복되는 버그 픽스
 
## Proposed changes
 - 저장하기 alert와 뒤로가기 alert 분리

## Changed Files
- [ ] WriteComplimentView.swift

## Checklist
- [ ] 오류없음

## Screenshot
x