### PR TITLE
[Feat] 저금통 깨기 기능 연결

### DIFF
--- a/Chinggu/Chinggu/Color.xcassets/ddogray.colorset/Contents.json
+++ b/Chinggu/Chinggu/Color.xcassets/ddogray.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x9C",
+          "green" : "0x9C",
+          "red" : "0x9C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Chinggu/Chinggu/MainView.swift
+++ b/Chinggu/Chinggu/MainView.swift
@@ -77,7 +77,7 @@ struct MainView: View {
     @State private var showBreakAlert = false
     @State private var tempSeletedWeekday: Weekday?
     @State private var shake = 0.0
-
+    @State private var showPopup = false
     @State private var isCompliment = false
 //    @AppStorage("isCompliment") var isCompliment: Bool = false
     
@@ -183,6 +183,7 @@ struct MainView: View {
                             .alert(isPresented: $showBreakAlert) {
                                 Alert(title: Text(canBreakBoxes ? "개봉 하시겠어요?" : "중도 개봉을 하시겠어요?"), primaryButton: .default(Text("예")) {
                                     // 저금통 초기화
+                                    showPopup = true
                                     scene.resetBoxes()
                                 }, secondaryButton:.cancel(Text("아니오")))
                             }
@@ -256,6 +257,11 @@ struct MainView: View {
                         .disabled(isCompliment)
                         .padding()
                     }
+                }
+                .blur(radius: showPopup ? 3 : 0)
+                .disabled(showPopup)
+                .popup(isPresented: $showPopup) {
+                    CardView(showPopup: $showPopup)
                 }
             }
         }

--- a/Chinggu/Chinggu/MainView.swift
+++ b/Chinggu/Chinggu/MainView.swift
@@ -77,8 +77,9 @@ struct MainView: View {
     @State private var showBreakAlert = false
     @State private var tempSeletedWeekday: Weekday?
     @State private var shake = 0.0
-//    @State private var isCompliment = false
-    @AppStorage("isCompliment") var isCompliment: Bool = false
+
+    @State private var isCompliment = false
+//    @AppStorage("isCompliment") var isCompliment: Bool = false
     
     @State var scene = GameScene()
     
@@ -86,7 +87,7 @@ struct MainView: View {
         GeometryReader { geometry in
             let width = geometry.size.width - geometry.safeAreaInsets.leading - geometry.safeAreaInsets.trailing - 40
             let height = width * 424 / 350
-//            let scene = GameScene(size: size, complimentCount: $complimentCount)
+
             NavigationView {
                 ZStack {
                     Color.ddoPrimary.ignoresSafeArea()
@@ -94,13 +95,17 @@ struct MainView: View {
                         //MARK: 요일 변경하는 버튼
                         HStack {
                             Text("매주")
-                                .tracking(-0.5)
+                                .font(.custom("AppleSDGothicNeo-SemiBold", size: 17))
+                                .foregroundColor(Color.ddoGray)
                             Button(action: {
                                 self.showActionSheet = true
                             }, label: {
                                 Text(selectedWeekday?.rawValue ?? "뭔요일")
-                                    .padding(.trailing, -7.0)
+                                    .font(.custom("AppleSDGothicNeo-Bold", size: 17))
+                                    .foregroundColor(.blue)
+                                    .padding(.trailing, -8.0)
                                 Image(systemName: "arrowtriangle.down.square.fill")
+                                    .foregroundColor(.blue)
                             })
                             .padding()
                             .actionSheet(isPresented: $showActionSheet) {
@@ -124,19 +129,46 @@ struct MainView: View {
                                 }, secondaryButton: .cancel(Text("아니오")))
                             }.padding(.horizontal, -19.0)
                             Text("은 칭찬 저금통을 깨는 날!")
-                                .tracking(-0.5)
+                                .font(.custom("AppleSDGothicNeo-SemiBold", size: 17))
+                                .foregroundColor(Color.ddoGray)
                             Spacer()
                             
                             //MARK: 아카이브 페이지 링크
                             NavigationLink(destination: TempMainView()) {
                                 Image(systemName: "archivebox")
+                                    .resizable()
+                                    .frame(width: 22, height: 22)
+                                    .foregroundColor(.black)
                             }
                         }.padding(.horizontal, 20.0)
+                            .padding(.bottom, -10.0)
+                        VStack(spacing: 0) {
+                            Divider()
+                                .padding(.top, 5)
+                            Rectangle()
+                                .fill(Color(.systemGray3))
+                                .frame(height: 5)
+                                .opacity(0.15)
+                            Divider()
+                        }
                         Spacer()
                         
                         // 타이틀
-                        Text("오늘은 어떤 칭찬을 해볼까요?✍️")
-                        
+                        if canBreakBoxes && scene.boxes.count > 0 {
+                            Text("저금통을\n확인 할 시간이에요💞")
+                                .multilineTextAlignment(.center)
+                                .font(.custom("AppleSDGothicNeo-Bold", size: 28))
+                                .foregroundColor(Color("oll"))
+                                .lineSpacing(5)
+                            
+                        } else {
+                            Text("오늘은 어떤 칭찬을\n해볼까요?✍️")
+                                .multilineTextAlignment(.center)
+                                .font(.custom("AppleSDGothicNeo-Bold", size: 28))
+                                .foregroundColor(Color("oll"))
+                                .lineSpacing(5)
+                        }
+                        Spacer()
                         //MARK: 칭찬 저금통
                         SpriteView(scene: scene)
                             .frame(width: width, height: height)
@@ -173,9 +205,6 @@ struct MainView: View {
                             .onAppear() {
                                 scene.size = CGSize(width: width, height: height)
                                 scene.complimentCount = Compliment.count
-//                                if isCompliment {
-//                                    scene.addBox(at: CGPoint(x: scene.size.width/2, y: scene.size.height - 50))
-//                                }
                                 print("appear",Compliment.count)
                                 updateCanBreakBoxes()
                                 resetTimeButton()
@@ -184,26 +213,44 @@ struct MainView: View {
                                     shake = 3
                                 }
                             }
-                        
+                        if canBreakBoxes && scene.boxes.count > 0 {
+                            Text("저금통을 탭해서 깨보세요!")
+                                .font(.custom("AppleSDGothicNeo-SemiBold", size: 14))
+                                .foregroundColor(Color.ddoGray)
+                                .padding(.top, 15)
+                        } else {
+                            Text("긍정의 힘은 복리로 돌아와요. 커밍쑨!")
+                                .font(.custom("AppleSDGothicNeo-SemiBold", size: 14))
+                                .foregroundColor(Color.ddoGray)
+                                .padding(.top, 15)
+                        }
                         Spacer()
                         // 칭찬돌 추가하는 버튼
-//                        Button(action: {
+                        Button(action: {
 //                            isCompliment = true
 //                            scene.addBox(at: CGPoint(x: scene.size.width/2, y: scene.size.height - 50))
-//                        }, label: {
-//                            NavigationLink(destination: WriteComplimentView(), label: {
-//                                Text("칭찬하기")
-//                                    .foregroundColor(.white)
-//                                    .padding(18.0)
-//                            })
-//                        })
-                        NavigationLink(destination: WriteComplimentView(isCompliment: $isCompliment), label: {
-                            Text("칭찬하기")
-                                .foregroundColor(.white)
-                                .padding(18.0)
+                        }, label: {
+                            NavigationLink(destination: WriteComplimentView(isCompliment: $isCompliment), label: {
+                                Text("칭찬하기")
+                                    .font(.custom("AppleSDGothicNeo-Bold", size: 20))
+                                    .foregroundColor(Color.white)
+                                    .kerning(1)
+                                    .padding(.vertical,6)
+                                    .frame(width: geometry.size.width/1.15, height: 50)
+                            })
                         })
+//                        .frame(width: geometry.size.width/1.15, height: 50)
+//                        .buttonStyle(BorderedButtonStyle())
+//                        .background(Color.ddoBlue)
+//                    .cornerRadius(10)
+                        
+//                        NavigationLink(destination: WriteComplimentView(isCompliment: $isCompliment), label: {
+//                            Text("칭찬하기")
+//                                .foregroundColor(.white)
+//                                .padding(18.0)
+//                        })
                         .background {
-                            RoundedRectangle(cornerRadius: 15)
+                            RoundedRectangle(cornerRadius: 10)
                                 .foregroundColor(isCompliment ? .gray : .blue)
                         }
                         .disabled(isCompliment)

--- a/Chinggu/Chinggu/Utils/Color+Chinggu.swift
+++ b/Chinggu/Chinggu/Utils/Color+Chinggu.swift
@@ -16,6 +16,7 @@ extension Color {
 	static let ddoPink = Color("ddoPink")
 	static let ddoBlue = Color("ddoBlue")
 	static let ddoYellow = Color("ddoYellow")
+    static let ddoGray = Color("ddoGray")
     static let ddoTip1 = Color("ddoTip1")
     static let ddoTip2 = Color("ddoTip2")
     static let ddoTip3 = Color("ddoTip3")

--- a/Chinggu/Chinggu/WriteComplimentView.swift
+++ b/Chinggu/Chinggu/WriteComplimentView.swift
@@ -157,7 +157,8 @@ struct WriteComplimentView: View {
                             }
                         }
                     }
-                    .padding()
+                    .padding(.horizontal, 17.0)
+                    .padding(.vertical, 4.0)
                     .sheet(isPresented: $presentSheet) {
                         VStack {
                             Text("칭찬요정 tip은 작성을 위한 참고 예시에요.")
@@ -199,7 +200,7 @@ struct WriteComplimentView: View {
                     .padding(.top, 5)
                 Rectangle()
                     .fill(Color(.systemGray3))
-                    .frame(height: 10)
+                    .frame(height: 5)
                     .opacity(0.15)
                 Divider()
             }


### PR DESCRIPTION
### Description
 - 메인뷰와 칭찬 작성뷰 디자인 디벨롭
 - 칭찬 저금통 탭할 시 카드 팝업 기능 연결
 
## Proposed changes
 - ddoGray라는 컬러 추가


## Changed Files
- [ ] MainView.swift
- [ ] WriteComplimentView.swift
- [ ] Color+Chinggu.swift

## Checklist
- [ ] 컴파일
- [ ] 오류없음

## Screenshot
<img width="855" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team13-Ddojeon/assets/102914072/6a34957a-cc2e-4d56-9077-2ace04e1f24a">
<img width="1144" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team13-Ddojeon/assets/102914072/83a9e7c7-e30e-49c5-9d2d-1908064c5d56">


## Further comments
 - 카드 팝업 시 뒤에 칭찬 저금통이 뚝 사라지는 것과 타이틀이 휙 바뀌는 걸 막고 싶은데 가능할지 모르겠네요..
